### PR TITLE
Adds GET rewards and deprecates reward.title and reward.description

### DIFF
--- a/src/controllers/rewards/_.validation.ts
+++ b/src/controllers/rewards/_.validation.ts
@@ -2,13 +2,7 @@ import { body, param } from 'express-validator';
 import { validateAssetPoolHeader } from '../../util/validation';
 
 export const validations = {
-    postReward: [
-        validateAssetPoolHeader,
-        body('title').exists(),
-        body('description').exists(),
-        body('withdrawAmount').exists(),
-        body('withdrawDuration').exists(),
-    ],
+    postReward: [validateAssetPoolHeader, body('withdrawAmount').exists(), body('withdrawDuration').exists()],
     getRewards: [validateAssetPoolHeader],
     getReward: [validateAssetPoolHeader, param('id').exists().isNumeric()],
     patchReward: [validateAssetPoolHeader, param('id').exists().isNumeric()],

--- a/src/controllers/rewards/get.action.ts
+++ b/src/controllers/rewards/get.action.ts
@@ -1,6 +1,7 @@
 import { Response, NextFunction } from 'express';
 import { Reward, RewardDocument } from '../../models/Reward';
 import { HttpError, HttpRequest } from '../../models/Error';
+import { formatEther } from 'ethers/lib/utils';
 
 /**
  * @swagger
@@ -72,9 +73,26 @@ import { HttpError, HttpRequest } from '../../models/Error';
 export const getRewards = async (req: HttpRequest, res: Response, next: NextFunction) => {
     try {
         try {
-            res.json({ rewards: [] });
+            const rewards = [];
+            let i = 1;
+            while (i >= 1) {
+                try {
+                    const { id, withdrawAmount, withdrawDuration, pollId, state } = await req.solution.getReward(i);
+                    rewards.push({
+                        id: id.toNumber(),
+                        withdrawAmount: formatEther(withdrawAmount),
+                        withdrawDuration: withdrawDuration.toNumber(),
+                        pollId: pollId.toNumber(),
+                        state,
+                    });
+                } catch (e) {
+                    break;
+                }
+                i++;
+            }
+            res.json({ rewards });
         } catch (err) {
-            next(new HttpError(404, 'Asset Pool get reward failed.', err));
+            next(new HttpError(404, 'Asset Pool get rewards failed.', err));
             return;
         }
     } catch (err) {

--- a/src/controllers/rewards/getReward.action.ts
+++ b/src/controllers/rewards/getReward.action.ts
@@ -42,7 +42,7 @@ import { formatEther } from 'ethers/lib/utils';
  *               type: object
  *               properties:
  *                  id:
- *                      type: string
+ *                      type: number
  *                      description: Unique identifier of the reward poll
  *                  withdrawAmount:
  *                      type: number

--- a/src/controllers/rewards/getReward.action.ts
+++ b/src/controllers/rewards/getReward.action.ts
@@ -75,14 +75,10 @@ import { HttpError, HttpRequest } from '../../models/Error';
  */
 export const getReward = async (req: HttpRequest, res: Response, next: NextFunction) => {
     try {
-        const metaData = await Reward.findOne({ id: req.params.id });
-
         try {
             const { id, withdrawAmount, withdrawDuration, pollId, state } = await req.solution.getReward(req.params.id);
             const reward = {
                 id: id.toNumber(),
-                title: metaData.title,
-                description: metaData.description,
                 withdrawAmount: withdrawAmount,
                 withdrawDuration: withdrawDuration.toNumber(),
                 state,

--- a/src/controllers/rewards/post.action.ts
+++ b/src/controllers/rewards/post.action.ts
@@ -11,20 +11,11 @@ import { parseLogs } from '../../util/events';
  *   post:
  *     tags:
  *       - Rewards
- *     description: Create a new reward in the asset pool
  *     produces:
  *       - application/json
  *     parameters:
  *       - name: AssetPool
  *         in: header
- *         required: true
- *         type: string
- *       - name: title
- *         in: body
- *         required: true
- *         type: string
- *       - name: description
- *         in: body
  *         required: true
  *         type: string
  *       - name: withdrawAmount
@@ -61,25 +52,21 @@ export const postReward = async (req: HttpRequest, res: Response, next: NextFunc
         try {
             const logs = await parseLogs(IDefaultDiamondArtifact.abi, tx.logs);
             const event = logs.filter((e: { name: string }) => e && e.name === 'RewardPollCreated')[0];
-            const id = parseInt(event.args.withdrawID, 10);
+            const id = parseInt(event.args.withdrawID, 10); // TODO Event output will be renamed to rewardID.
 
             new Reward({
                 id,
-                title: req.body.title,
-                description: req.body.description,
             }).save(async (err) => {
                 if (err) {
-                    next(new HttpError(502, 'Reward save failed.', err));
-                    return;
+                    return next(new HttpError(502, 'Reward save failed.', err));
                 }
 
                 res.redirect(`/${VERSION}/rewards/${id}`);
             });
         } catch (err) {
-            next(new HttpError(502, 'Parse logs failed.', err));
-            return;
+            return next(new HttpError(502, 'Parse logs failed.', err));
         }
     } catch (err) {
-        next(new HttpError(502, 'Asset Pool addReward failed.', err));
+        return next(new HttpError(502, 'Asset Pool addReward failed.', err));
     }
 };

--- a/src/models/Reward.ts
+++ b/src/models/Reward.ts
@@ -4,14 +4,11 @@ export type RewardDocument = mongoose.Document & {
     withdrawAmount: number;
     withdrawDuration: number;
     state: number;
-    pollId: number;
     poll: {
-        pollId: number;
-        finalized: boolean;
+        id: number;
         withdrawAmount: number;
         withdrawDuration: number;
-    } | null;
-    updated: string;
+    };
 };
 
 const rewardSchema = new mongoose.Schema(

--- a/src/models/Reward.ts
+++ b/src/models/Reward.ts
@@ -1,8 +1,6 @@
 import mongoose from 'mongoose';
 export type RewardDocument = mongoose.Document & {
     id: number;
-    title: string;
-    description: string;
     withdrawAmount: number;
     withdrawDuration: number;
     state: number;
@@ -19,8 +17,6 @@ export type RewardDocument = mongoose.Document & {
 const rewardSchema = new mongoose.Schema(
     {
         id: Number,
-        title: String,
-        description: String,
     },
     { timestamps: true },
 );

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "title": "THX API Specification",
-    "version": "1.0.0-beta.4"
+    "version": "1.0.0-beta.5"
   },
   "basePath": "https://api.thx.network/v1",
   "swagger": "2.0",
@@ -1150,46 +1150,51 @@
         "responses": {
           "200": {
             "schema": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "number",
-                  "description": "Unique identifier of the reward."
-                },
-                "title": {
-                  "type": "string",
-                  "description": null
-                },
-                "description": {
-                  "type": "string",
-                  "description": "The description"
-                },
-                "withdrawAmount": {
-                  "type": "number",
-                  "description": "Current size of the reward"
-                },
-                "withdrawDuration": {
-                  "type": "number",
-                  "description": "Current duration of the withdraw poll"
-                },
-                "state": {
-                  "type": "number",
-                  "description": "Current state of the reward [Enabled, Disabled]"
-                },
-                "poll": {
+              "rewards": {
+                "type": "array",
+                "items": {
                   "type": "object",
                   "properties": {
-                    "address": {
+                    "id": {
+                      "type": "number",
+                      "description": "Unique identifier of the reward."
+                    },
+                    "title": {
                       "type": "string",
-                      "description": "Address of the reward poll"
+                      "description": null
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "The description"
                     },
                     "withdrawAmount": {
                       "type": "number",
-                      "description": "Proposed size of the reward"
+                      "description": "Current size of the reward"
                     },
                     "withdrawDuration": {
                       "type": "number",
-                      "description": "Proposed duration of the withdraw poll"
+                      "description": "Current duration of the withdraw poll"
+                    },
+                    "state": {
+                      "type": "number",
+                      "description": "Current state of the reward [Enabled, Disabled]"
+                    },
+                    "poll": {
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "type": "string",
+                          "description": "Address of the reward poll"
+                        },
+                        "withdrawAmount": {
+                          "type": "number",
+                          "description": "Proposed size of the reward"
+                        },
+                        "withdrawDuration": {
+                          "type": "number",
+                          "description": "Proposed duration of the withdraw poll"
+                        }
+                      }
                     }
                   }
                 }
@@ -1228,7 +1233,6 @@
         "tags": [
           "Rewards"
         ],
-        "description": "Create a new reward in the asset pool",
         "produces": [
           "application/json"
         ],
@@ -1236,18 +1240,6 @@
           {
             "name": "AssetPool",
             "in": "header",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "title",
-            "in": "body",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "description",
-            "in": "body",
             "required": true,
             "type": "string"
           },

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1159,14 +1159,6 @@
                       "type": "number",
                       "description": "Unique identifier of the reward."
                     },
-                    "title": {
-                      "type": "string",
-                      "description": null
-                    },
-                    "description": {
-                      "type": "string",
-                      "description": "The description"
-                    },
                     "withdrawAmount": {
                       "type": "number",
                       "description": "Current size of the reward"
@@ -1177,14 +1169,14 @@
                     },
                     "state": {
                       "type": "number",
-                      "description": "Current state of the reward [Enabled, Disabled]"
+                      "description": "Current state of the reward [Disabled, Enabled]"
                     },
                     "poll": {
                       "type": "object",
                       "properties": {
-                        "address": {
-                          "type": "string",
-                          "description": "Address of the reward poll"
+                        "id": {
+                          "type": "number",
+                          "description": "Unique identifier of the reward poll"
                         },
                         "withdrawAmount": {
                           "type": "number",
@@ -1198,14 +1190,6 @@
                     }
                   }
                 }
-              }
-            }
-          },
-          "302": {
-            "description": "Redirect to `GET /rewards/:id`",
-            "headers": {
-              "Location": {
-                "type": "string"
               }
             }
           },
@@ -1318,14 +1302,6 @@
                   "type": "number",
                   "description": "Unique identifier of the reward."
                 },
-                "title": {
-                  "type": "string",
-                  "description": null
-                },
-                "description": {
-                  "type": "string",
-                  "description": "The description"
-                },
                 "withdrawAmount": {
                   "type": "number",
                   "description": "Current size of the reward"
@@ -1341,9 +1317,9 @@
                 "poll": {
                   "type": "object",
                   "properties": {
-                    "address": {
-                      "type": "string",
-                      "description": "Address of the reward poll"
+                    "id": {
+                      "type": "number",
+                      "description": "Unique identifier of the reward poll"
                     },
                     "withdrawAmount": {
                       "type": "number",
@@ -1408,18 +1384,6 @@
             "in": "path",
             "required": true,
             "type": "integer"
-          },
-          {
-            "name": "title",
-            "in": "body",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "name": "description",
-            "in": "body",
-            "required": true,
-            "type": "string"
           },
           {
             "name": "withdrawAmount",

--- a/test/e2e/api.ts
+++ b/test/e2e/api.ts
@@ -229,13 +229,11 @@ describe('Happy Flow', () => {
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
                 .end(async (err, res) => {
                     expect(res.status).toBe(200);
-                    expect(Number(res.body.id)).toEqual(1);
-                    expect(res.body.poll.pollId).toEqual(1);
-                    expect(Number(res.body.poll.withdrawDuration)).toEqual(rewardWithdrawDuration);
-                    expect(Number(formatEther(res.body.poll.withdrawAmount))).toEqual(
-                        Number(formatEther(rewardWithdrawAmount)),
-                    );
-                    pollID = res.body.poll.pollId;
+                    expect(res.body.id).toEqual(1);
+                    expect(res.body.poll.id).toEqual(1);
+                    expect(res.body.poll.withdrawDuration).toEqual(rewardWithdrawDuration);
+                    expect(res.body.poll.withdrawAmount).toEqual(Number(formatEther(rewardWithdrawAmount)));
+                    pollID = res.body.poll.id;
 
                     done();
                 });
@@ -316,11 +314,11 @@ describe('Happy Flow', () => {
             await timeTravel(rewardPollDuration);
         });
 
-        it('HTTP 200  reward.pollId = 1', (done) => {
+        it('HTTP 200  reward.id = 1', (done) => {
             user.get('/v1/rewards/1')
                 .set({ AssetPool: poolAddress, Authorization: userAccessToken })
                 .end(async (err, res) => {
-                    expect(res.body.pollId).toBe(1);
+                    expect(res.body.poll.id).toBe(1);
                     expect(res.status).toBe(200);
                     done();
                 });
@@ -339,7 +337,7 @@ describe('Happy Flow', () => {
             user.get('/v1/rewards/1')
                 .set({ AssetPool: poolAddress, Authorization: userAccessToken })
                 .end(async (err, res) => {
-                    expect(res.body.pollId).toBe(0);
+                    expect(res.body.poll).toBeUndefined();
                     expect(res.status).toBe(200);
                     done();
                 });
@@ -351,10 +349,8 @@ describe('Happy Flow', () => {
             user.get('/v1/rewards/1')
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
                 .end(async (err, res) => {
-                    expect(Number(formatEther(res.body.withdrawAmount))).toEqual(
-                        Number(formatEther(rewardWithdrawAmount)),
-                    );
-                    expect(Number(res.body.state)).toEqual(1);
+                    expect(res.body.withdrawAmount).toEqual(Number(formatEther(rewardWithdrawAmount)));
+                    expect(res.body.state).toEqual(1);
                     expect(res.status).toBe(200);
                     done();
                 });

--- a/test/e2e/api.ts
+++ b/test/e2e/api.ts
@@ -7,15 +7,13 @@ import {
     poolTitle,
     rewardPollDuration,
     proposeWithdrawPollDuration,
-    rewardTitle,
-    rewardDescription,
     rewardWithdrawAmount,
     rewardWithdrawDuration,
     mintAmount,
     userEmail,
     userPassword,
 } from './lib/constants';
-import { formatEther, parseEther } from 'ethers/lib/utils';
+import { formatEther } from 'ethers/lib/utils';
 import { Contract, ethers, Wallet } from 'ethers';
 import {
     getAccessToken,
@@ -218,8 +216,6 @@ describe('Happy Flow', () => {
                 .send({
                     withdrawAmount: rewardWithdrawAmount,
                     withdrawDuration: rewardWithdrawDuration,
-                    title: rewardTitle,
-                    description: rewardDescription,
                 })
                 .end(async (err, res) => {
                     redirectURL = res.headers.location;
@@ -234,8 +230,6 @@ describe('Happy Flow', () => {
                 .end(async (err, res) => {
                     expect(res.status).toBe(200);
                     expect(Number(res.body.id)).toEqual(1);
-                    expect(res.body.title).toEqual(rewardTitle);
-                    expect(res.body.description).toEqual(rewardDescription);
                     expect(res.body.poll.pollId).toEqual(1);
                     expect(Number(res.body.poll.withdrawDuration)).toEqual(rewardWithdrawDuration);
                     expect(Number(formatEther(res.body.poll.withdrawAmount))).toEqual(

--- a/test/e2e/bypasspoll.ts
+++ b/test/e2e/bypasspoll.ts
@@ -69,9 +69,9 @@ describe('Bypass Polls', () => {
                 })
                 .end((err, res) => {
                     expect(res.status).toBe(200);
-                    expect(res.body.pollId).toBe(1);
+                    expect(res.body.poll.id).toBe(1);
                     expect(res.body.state).toBe(0);
-                    pollID = res.body.pollId;
+                    pollID = res.body.poll.id;
                     done();
                 });
         });
@@ -100,7 +100,7 @@ describe('Bypass Polls', () => {
                 })
                 .end((err, res) => {
                     expect(res.status).toBe(200);
-                    expect(res.body.pollId).toBe(0);
+                    expect(res.body.poll).toBeUndefined();
                     expect(res.body.state).toBe(0);
 
                     done();
@@ -139,9 +139,9 @@ describe('Bypass Polls', () => {
                 })
                 .end((err, res) => {
                     expect(res.status).toBe(200);
-                    expect(res.body.pollId).toBe(2);
+                    expect(res.body.poll.id).toBe(2);
                     expect(res.body.state).toBe(0);
-                    pollID = res.body.pollId;
+                    pollID = res.body.poll.id;
                     done();
                 });
         });
@@ -170,7 +170,7 @@ describe('Bypass Polls', () => {
                 })
                 .end((err, res) => {
                     expect(res.status).toBe(200);
-                    expect(res.body.pollId).toBe(0);
+                    expect(res.body.poll).toBeUndefined();
                     expect(res.body.state).toBe(1);
 
                     done();
@@ -209,9 +209,9 @@ describe('Bypass Polls', () => {
                 })
                 .end((err, res) => {
                     expect(res.status).toBe(200);
-                    expect(res.body.pollId).toBe(3);
+                    expect(res.body.poll.id).toBe(3);
                     expect(res.body.state).toBe(0);
-                    pollID = res.body.pollId;
+                    pollID = res.body.poll.id;
                     done();
                 });
         });
@@ -244,7 +244,7 @@ describe('Bypass Polls', () => {
                 })
                 .end((err, res) => {
                     expect(res.status).toBe(200);
-                    expect(res.body.pollId).toBe(0);
+                    expect(res.body.poll).toBeUndefined();
                     expect(res.body.state).toBe(1);
 
                     done();

--- a/test/e2e/bypasspoll.ts
+++ b/test/e2e/bypasspoll.ts
@@ -52,8 +52,6 @@ describe('Bypass Polls', () => {
                 .send({
                     withdrawAmount: '20000000000000000000',
                     withdrawDuration: '0',
-                    title: 'Complete your profile!',
-                    description: 'You should do this and that...',
                 })
                 .end((err, res) => {
                     expect(res.status).toBe(302);
@@ -124,8 +122,6 @@ describe('Bypass Polls', () => {
                 .send({
                     withdrawAmount: '20000000000000000000',
                     withdrawDuration: '0',
-                    title: 'Complete your profile!',
-                    description: 'You should do this and that...',
                 })
                 .end((err, res) => {
                     expect(res.status).toBe(302);
@@ -196,8 +192,6 @@ describe('Bypass Polls', () => {
                 .send({
                     withdrawAmount: '20000000000000000000',
                     withdrawDuration: '0',
-                    title: 'Complete your profile!',
-                    description: 'You should do this and that...',
                 })
                 .end((err, res) => {
                     expect(res.status).toBe(302);

--- a/test/e2e/gasStation.ts
+++ b/test/e2e/gasStation.ts
@@ -7,8 +7,6 @@ import {
     poolTitle,
     rewardPollDuration,
     proposeWithdrawPollDuration,
-    rewardTitle,
-    rewardDescription,
     rewardWithdrawAmount,
     rewardWithdrawDuration,
     mintAmount,
@@ -25,12 +23,7 @@ const user = request(server);
 const http2 = request.agent(server);
 
 describe('Gas Station', () => {
-    let poolAddress: any,
-        pollId: any,
-        withdrawPollAddress: any,
-        adminAccessToken: string,
-        userAccessToken: string,
-        testToken: any;
+    let poolAddress: any, pollId: any, adminAccessToken: string, userAccessToken: string, testToken: any;
 
     beforeAll(async () => {
         await db.truncate();
@@ -82,8 +75,6 @@ describe('Gas Station', () => {
         await user.post('/v1/rewards/').set({ AssetPool: poolAddress, Authorization: adminAccessToken }).send({
             withdrawAmount: rewardWithdrawAmount,
             withdrawDuration: rewardWithdrawDuration,
-            title: rewardTitle,
-            description: rewardDescription,
         });
 
         // Add a member

--- a/test/e2e/gasStation.ts
+++ b/test/e2e/gasStation.ts
@@ -89,7 +89,7 @@ describe('Gas Station', () => {
             const { body, status } = await user
                 .get('/v1/rewards/1')
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken });
-            pollId = body.poll.poll.id;
+            pollId = body.poll.id;
             expect(body.state).toBe(0);
             done();
         });

--- a/test/e2e/gasStation.ts
+++ b/test/e2e/gasStation.ts
@@ -89,7 +89,7 @@ describe('Gas Station', () => {
             const { body, status } = await user
                 .get('/v1/rewards/1')
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken });
-            pollId = body.poll.pollId;
+            pollId = body.poll.poll.id;
             expect(body.state).toBe(0);
             done();
         });

--- a/test/e2e/lib/constants.ts
+++ b/test/e2e/lib/constants.ts
@@ -3,8 +3,6 @@ import { parseEther } from 'ethers/lib/utils';
 export const poolTitle = 'Volunteers United';
 export const rewardPollDuration = 10;
 export const proposeWithdrawPollDuration = 10;
-export const rewardTitle = 'Complete your profile!';
-export const rewardDescription = 'Earn great rewards for tiny things.';
 export const rewardWithdrawAmount = parseEther('1000');
 export const rewardWithdrawDuration = 12;
 export const VOTER_PK = '0x97093724e1748ebfa6aa2d2ec4ec68df8678423ab9a12eb2d27ddc74e35e5db9';

--- a/test/e2e/voting.ts
+++ b/test/e2e/voting.ts
@@ -6,16 +6,13 @@ import { exampleTokenFactory } from './lib/contracts';
 import {
     poolTitle,
     rewardPollDuration,
-    proposeWithdrawPollDuration,
-    rewardTitle,
-    rewardDescription,
     rewardWithdrawAmount,
     rewardWithdrawDuration,
     mintAmount,
     userEmail,
     userPassword,
 } from './lib/constants';
-import { formatEther, parseEther } from 'ethers/lib/utils';
+import { parseEther } from 'ethers/lib/utils';
 import { Contract, ethers, Wallet } from 'ethers';
 import {
     getAccessToken,
@@ -35,8 +32,8 @@ describe('Voting', () => {
         userAccessToken: string,
         poolAddress: string,
         pollID: string,
+        // withdrawPollID: number,
         userAddress: string,
-        withdrawPollID: string,
         userWallet: Wallet,
         testToken: Contract;
 
@@ -153,8 +150,6 @@ describe('Voting', () => {
                 .send({
                     withdrawAmount: rewardWithdrawAmount,
                     withdrawDuration: rewardWithdrawDuration,
-                    title: rewardTitle,
-                    description: rewardDescription,
                 })
                 .end(async (err, res) => {
                     expect(res.status).toBe(302);
@@ -297,7 +292,7 @@ describe('Voting', () => {
                 .end(async (err, res) => {
                     // one claimRewardFor and one proposeWithdraw
                     expect(Number(res.body.withdrawPolls.length)).toBe(1);
-                    withdrawPollID = res.body.withdrawPolls[0];
+                    // withdrawPollID = res.body.withdrawPolls[0];
                     expect(res.status).toBe(200);
                     done();
                 });

--- a/test/e2e/voting.ts
+++ b/test/e2e/voting.ts
@@ -163,8 +163,8 @@ describe('Voting', () => {
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
                 .end(async (err, res) => {
                     expect(res.status).toBe(200);
-                    expect(res.body.poll.pollId).toEqual(1);
-                    pollID = res.body.poll.pollId;
+                    expect(res.body.poll.id).toEqual(1);
+                    pollID = res.body.poll.id;
                     done();
                 });
         });


### PR DESCRIPTION
This PR deprecates the use and storage of `Reward.title` and `Reward.description` since only the ID is required for client integration and this metadata is usually already stored client side and potentially changing.