### PR TITLE
Feature/update bypasspolls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "thx-api",
-    "version": "1.0.0-beta.6",
+    "version": "1.0.0-beta.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "thx-api",
-    "version": "1.0.0-beta.6",
+    "version": "1.0.0-beta.7",
     "description": "Public API for THX protocol.",
     "repository": {
         "type": "git",

--- a/src/controllers/asset_pools/get.action.ts
+++ b/src/controllers/asset_pools/get.action.ts
@@ -85,16 +85,14 @@ export const getAssetPool = async (req: HttpRequest, res: Response, next: NextFu
             const assetPool: AssetPoolDocument = await AssetPool.findOne({
                 address: req.params.address,
             });
+
             if (!assetPool) {
                 return next(new HttpError(404, 'Asset Pool is not found in database.'));
             }
-            const { address, title } = assetPool;
 
-            if (!address) {
-                return next(new HttpError(404, 'Asset Pool is not found in database.'));
-            }
+            const { address, title, bypassPolls } = assetPool;
 
-            res.json({ title, address, ...contractData });
+            res.json({ title, address, bypassPolls, ...contractData });
         } catch (error) {
             next(new HttpError(500, 'Asset Pool network data can not be obtained.', error));
         }

--- a/src/controllers/asset_pools/patch.action.ts
+++ b/src/controllers/asset_pools/patch.action.ts
@@ -1,6 +1,8 @@
+import { downgradeFromBypassPolls, updateToBypassPolls } from '../../util/network';
 import { Response, NextFunction } from 'express';
 import { VERSION } from '../../util/secrets';
 import { HttpRequest, HttpError } from '../../models/Error';
+import { AssetPool } from '../../models/AssetPool';
 
 /**
  * @swagger
@@ -45,6 +47,31 @@ import { HttpRequest, HttpError } from '../../models/Error';
  *         description: Bad Gateway. Received an invalid response from the network or database.
  */
 export const patchAssetPool = async (req: HttpRequest, res: Response, next: NextFunction) => {
+    const assetPool = await AssetPool.findOne({
+        address: req.solution.address,
+    });
+
+    if (req.body.bypassPolls === true && assetPool.bypassPolls === false) {
+        try {
+            await updateToBypassPolls(req.solution);
+            assetPool.bypassPolls = req.body.bypassPolls;
+
+            await assetPool.save();
+        } catch (error) {
+            return next(new HttpError(502, 'Asset Pool updateToBypassPolls failed.', error));
+        }
+    }
+
+    if (req.body.bypassPolls === false && assetPool.bypassPolls === true) {
+        try {
+            await downgradeFromBypassPolls(req.solution);
+            assetPool.bypassPolls = req.body.bypassPolls;
+            await assetPool.save();
+        } catch (error) {
+            return next(new HttpError(502, 'Asset Pool downgradeFromBypassPolls failed.', error));
+        }
+    }
+
     if (
         req.body.rewardPollDuration &&
         (await req.solution.getRewardPollDuration()).toString() !== req.body.rewardPollDuration.toString()
@@ -67,6 +94,5 @@ export const patchAssetPool = async (req: HttpRequest, res: Response, next: Next
             return next(new HttpError(502, 'Asset Pool setProposeWithdrawPollDuration failed.', error));
         }
     }
-
     res.redirect(`/${VERSION}/asset_pools/${req.params.address}`);
 };

--- a/src/controllers/asset_pools/patch.action.ts
+++ b/src/controllers/asset_pools/patch.action.ts
@@ -10,7 +10,7 @@ import { AssetPool } from '../../models/AssetPool';
  *   patch:
  *     tags:
  *       - Asset Pools
- *     description: Update the configuration for this asset pool
+ *     description: Update the configuration for this asset pool. RewardPollDuration and ProposeWithdrawPollDuration are set in seconds. BypassPolls will upgrade the contracts reward module.
  *     produces:
  *       - application/json
  *     parameters:
@@ -22,13 +22,17 @@ import { AssetPool } from '../../models/AssetPool';
  *         in: path
  *         required: true
  *         type: string
+ *       - name: bypassPolls
+ *         in: body
+ *         required: false
+ *         type: boolean
  *       - name: rewardPollDuration
  *         in: body
- *         required: true
+ *         required: false
  *         type: integer
  *       - name: proposeWithdrawPollDuration
  *         in: body
- *         required: true
+ *         required: false
  *         type: integer
  *     responses:
  *       '200':

--- a/src/controllers/polls/postPollFinalize.action.ts
+++ b/src/controllers/polls/postPollFinalize.action.ts
@@ -42,7 +42,6 @@ import { NextFunction, Response } from 'express';
 export const postPollFinalize = async (req: HttpRequest, res: Response, next: NextFunction) => {
     try {
         const tx = await (await req.solution.rewardPollFinalize(req.params.id)).wait();
-
         res.json({ transactionHash: tx.transactionHash });
     } catch (err) {
         next(new HttpError(502, 'BasePoll finalize failed.', err));

--- a/src/controllers/rewards/getReward.action.ts
+++ b/src/controllers/rewards/getReward.action.ts
@@ -1,5 +1,5 @@
 import { Response, NextFunction } from 'express';
-import { Reward, RewardDocument } from '../../models/Reward';
+import { RewardDocument } from '../../models/Reward';
 import { HttpError, HttpRequest } from '../../models/Error';
 import { formatEther } from 'ethers/lib/utils';
 
@@ -37,7 +37,7 @@ import { formatEther } from 'ethers/lib/utils';
  *               description: Current duration of the withdraw poll
  *             state:
  *               type: number
- *               description: Current state of the reward [Enabled, Disabled]
+ *               description: Current state of the reward [Disabled, Enabled]
  *             poll:
  *               type: object
  *               properties:

--- a/src/controllers/rewards/patch.action.ts
+++ b/src/controllers/rewards/patch.action.ts
@@ -51,7 +51,7 @@ import qrcode from 'qrcode';
  */
 export const patchReward = async (req: HttpRequest, res: Response, next: NextFunction) => {
     try {
-        let { withdrawAmount, withdrawDuration } = await req.solution.rewards(req.params.id);
+        let { withdrawAmount, withdrawDuration } = await req.solution.getReward(req.params.id);
 
         if (req.body.withdrawAmount && withdrawAmount !== req.body.withdrawAmount) {
             withdrawAmount = req.body.withdrawAmount;

--- a/src/controllers/rewards/post.action.ts
+++ b/src/controllers/rewards/post.action.ts
@@ -5,6 +5,7 @@ import { VERSION } from '../../util/secrets';
 import IDefaultDiamondArtifact from '../../../src/artifacts/contracts/contracts/IDefaultDiamond.sol/IDefaultDiamond.json';
 
 import { parseLogs } from '../../util/events';
+import { parseEther } from 'ethers/lib/utils';
 /**
  * @swagger
  * /rewards:
@@ -47,12 +48,13 @@ import { parseLogs } from '../../util/events';
  */
 export const postReward = async (req: HttpRequest, res: Response, next: NextFunction) => {
     try {
-        const tx = await (await req.solution.addReward(req.body.withdrawAmount, req.body.withdrawDuration)).wait();
+        const withdrawAmount = parseEther(req.body.withdrawAmount.toString());
+        const tx = await (await req.solution.addReward(withdrawAmount, req.body.withdrawDuration)).wait();
 
         try {
             const logs = await parseLogs(IDefaultDiamondArtifact.abi, tx.logs);
             const event = logs.filter((e: { name: string }) => e && e.name === 'RewardPollCreated')[0];
-            const id = parseInt(event.args.withdrawID, 10); // TODO Event output will be renamed to rewardID.
+            const id = parseInt(event.args.withdrawID, 10);
 
             new Reward({
                 id,

--- a/src/models/AssetPool.ts
+++ b/src/models/AssetPool.ts
@@ -6,6 +6,7 @@ export type AssetPoolDocument = mongoose.Document & {
     client: string;
     blockNumber: number;
     transactionHash: string;
+    bypassPolls: boolean;
 };
 
 const assetPoolSchema = new mongoose.Schema(
@@ -15,6 +16,7 @@ const assetPoolSchema = new mongoose.Schema(
         client: String,
         blockNumber: Number,
         transactionHash: String,
+        bypassPolls: Boolean,
     },
     { timestamps: true },
 );

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -276,7 +276,7 @@
         "tags": [
           "Asset Pools"
         ],
-        "description": "Update the configuration for this asset pool",
+        "description": "Update the configuration for this asset pool. RewardPollDuration and ProposeWithdrawPollDuration are set in seconds. BypassPolls will upgrade the contracts reward module.",
         "produces": [
           "application/json"
         ],
@@ -294,15 +294,21 @@
             "type": "string"
           },
           {
+            "name": "bypassPolls",
+            "in": "body",
+            "required": false,
+            "type": "boolean"
+          },
+          {
             "name": "rewardPollDuration",
             "in": "body",
-            "required": true,
+            "required": false,
             "type": "integer"
           },
           {
             "name": "proposeWithdrawPollDuration",
             "in": "body",
-            "required": true,
+            "required": false,
             "type": "integer"
           }
         ],

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "title": "THX API Specification",
-    "version": "1.0.0-beta.6"
+    "version": "1.0.0-beta.7"
   },
   "basePath": "https://api.thx.network/v1",
   "swagger": "2.0",
@@ -1312,7 +1312,7 @@
                 },
                 "state": {
                   "type": "number",
-                  "description": "Current state of the reward [Enabled, Disabled]"
+                  "description": "Current state of the reward [Disabled, Enabled]"
                 },
                 "poll": {
                   "type": "object",

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -28,7 +28,7 @@ export const logger = instance;
 export const requestLogger = morgan(
     ':remote-addr - :remote-user ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"',
     {
-        skip: (req: Request) => ENVIRONMENT === 'test' || req.baseUrl.startsWith(`/${VERSION}/ping`),
+        skip: (req: Request) => ENVIRONMENT === 'wtest' || req.baseUrl.startsWith(`/${VERSION}/ping`),
         stream: {
             write: (message: string) => instance.info(message.substring(0, message.lastIndexOf('\n'))),
         },

--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -131,27 +131,13 @@ export const updateToBypassPolls = async (solution: Contract) => {
     const rewardByPollFacet = await rewardByPollFacetFactory.deploy();
     const rewardByPollProxyFacet = await rewardByPollProxyFacetFactory.deploy();
 
-    logTransaction(
-        await (await solution.updateAssetPool(getSelectors(withdrawByFacet), withdrawByFacet.address)).wait(),
-    );
-    logTransaction(
-        await (await solution.updateAssetPool(getSelectors(withdrawByPollFacet), withdrawByPollFacet.address)).wait(),
-    );
-    logTransaction(
-        await (
-            await solution.updateAssetPool(getSelectors(withdrawByPollProxyFacet), withdrawByPollProxyFacet.address)
-        ).wait(),
-    );
+    await solution.updateAssetPool(getSelectors(withdrawByFacet), withdrawByFacet.address);
+    await solution.updateAssetPool(getSelectors(withdrawByPollFacet), withdrawByPollFacet.address);
+    await solution.updateAssetPool(getSelectors(withdrawByPollProxyFacet), withdrawByPollProxyFacet.address);
 
-    logTransaction(await (await solution.updateAssetPool(getSelectors(rewardByFacet), rewardByFacet.address)).wait());
-    logTransaction(
-        await (await solution.updateAssetPool(getSelectors(rewardByPollFacet), rewardByPollFacet.address)).wait(),
-    );
-    logTransaction(
-        await (
-            await solution.updateAssetPool(getSelectors(rewardByPollProxyFacet), rewardByPollProxyFacet.address)
-        ).wait(),
-    );
+    await solution.updateAssetPool(getSelectors(rewardByFacet), rewardByFacet.address);
+    await solution.updateAssetPool(getSelectors(rewardByPollFacet), rewardByPollFacet.address);
+    await solution.updateAssetPool(getSelectors(rewardByPollProxyFacet), rewardByPollProxyFacet.address);
 };
 
 // export const updateToBypassPolls = async (solution: Contract) => {

--- a/test/e2e/api.ts
+++ b/test/e2e/api.ts
@@ -13,7 +13,7 @@ import {
     userEmail,
     userPassword,
 } from './lib/constants';
-import { formatEther } from 'ethers/lib/utils';
+import { formatEther, parseEther } from 'ethers/lib/utils';
 import { Contract, ethers, Wallet } from 'ethers';
 import {
     getAccessToken,
@@ -107,10 +107,24 @@ describe('Happy Flow', () => {
         });
     });
 
+    describe('PATCH /asset_pools/:address (bypassPolls = true)', () => {
+        it('HTTP 302 ', (done) => {
+            user.patch('/v1/asset_pools/' + poolAddress)
+                .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
+                .send({
+                    bypassPolls: true,
+                })
+                .end(async (err, res) => {
+                    expect(res.status).toBe(302);
+                    done();
+                });
+        });
+    });
+
     describe('GET /asset_pools/:address', () => {
         it('HTTP 200 and expose pool information', async (done) => {
             // Transfer some tokens to the pool rewardWithdrawAmount tokens for the pool
-            await testToken.transfer(poolAddress, rewardWithdrawAmount);
+            await testToken.transfer(poolAddress, parseEther(rewardWithdrawAmount.toString()));
 
             user.get('/v1/asset_pools/' + poolAddress)
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
@@ -118,14 +132,14 @@ describe('Happy Flow', () => {
                     const adminBalance = await testToken.balanceOf(admin.address);
 
                     expect(Number(formatEther(adminBalance))).toBe(
-                        Number(formatEther(mintAmount)) - Number(formatEther(rewardWithdrawAmount)),
+                        Number(formatEther(mintAmount)) - rewardWithdrawAmount,
                     );
                     expect(res.body.title).toEqual(poolTitle);
                     expect(res.body.address).toEqual(poolAddress);
                     expect(res.body.token.address).toEqual(testToken.address);
                     expect(res.body.token.name).toEqual(await testToken.name());
                     expect(res.body.token.symbol).toEqual(await testToken.symbol());
-                    expect(Number(formatEther(res.body.token.balance))).toBe(Number(formatEther(rewardWithdrawAmount)));
+                    expect(Number(formatEther(res.body.token.balance))).toBe(rewardWithdrawAmount);
                     expect(Number(res.body.proposeWithdrawPollDuration)).toEqual(0);
                     expect(Number(res.body.rewardPollDuration)).toEqual(0);
                     expect(res.status).toBe(200);
@@ -199,6 +213,7 @@ describe('Happy Flow', () => {
             user.get('/v1/asset_pools/' + poolAddress)
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
                 .end(async (err, res) => {
+                    expect(res.body.bypassPolls).toEqual(true);
                     expect(Number(res.body.proposeWithdrawPollDuration)).toEqual(proposeWithdrawPollDuration);
                     expect(Number(res.body.rewardPollDuration)).toEqual(rewardPollDuration);
                     expect(res.status).toBe(200);
@@ -218,8 +233,8 @@ describe('Happy Flow', () => {
                     withdrawDuration: rewardWithdrawDuration,
                 })
                 .end(async (err, res) => {
-                    redirectURL = res.headers.location;
                     expect(res.status).toBe(302);
+                    redirectURL = res.headers.location;
                     done();
                 });
         });
@@ -232,9 +247,8 @@ describe('Happy Flow', () => {
                     expect(res.body.id).toEqual(1);
                     expect(res.body.poll.id).toEqual(1);
                     expect(res.body.poll.withdrawDuration).toEqual(rewardWithdrawDuration);
-                    expect(res.body.poll.withdrawAmount).toEqual(Number(formatEther(rewardWithdrawAmount)));
+                    expect(res.body.poll.withdrawAmount).toEqual(rewardWithdrawAmount);
                     pollID = res.body.poll.id;
-
                     done();
                 });
         });
@@ -277,9 +291,9 @@ describe('Happy Flow', () => {
                 .send({ address: userAddress })
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
                 .end(async (err, res) => {
+                    expect(res.status).toBe(302);
                     redirectURL = res.headers.location;
 
-                    expect(res.status).toBe(302);
                     done();
                 });
         });
@@ -289,9 +303,9 @@ describe('Happy Flow', () => {
                 .send({ isManager: true })
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
                 .end(async (err, res) => {
+                    expect(res.status).toBe(302);
                     redirectURL = res.headers.location;
 
-                    expect(res.status).toBe(302);
                     done();
                 });
         });
@@ -314,12 +328,13 @@ describe('Happy Flow', () => {
             await timeTravel(rewardPollDuration);
         });
 
-        it('HTTP 200  reward.id = 1', (done) => {
+        it('HTTP 200 reward.id = 1', (done) => {
             user.get('/v1/rewards/1')
                 .set({ AssetPool: poolAddress, Authorization: userAccessToken })
                 .end(async (err, res) => {
-                    expect(res.body.poll.id).toBe(1);
                     expect(res.status).toBe(200);
+                    expect(res.body.poll.id).toBe(1);
+
                     done();
                 });
         });
@@ -349,9 +364,10 @@ describe('Happy Flow', () => {
             user.get('/v1/rewards/1')
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
                 .end(async (err, res) => {
-                    expect(res.body.withdrawAmount).toEqual(Number(formatEther(rewardWithdrawAmount)));
-                    expect(res.body.state).toEqual(1);
                     expect(res.status).toBe(200);
+                    expect(res.body.withdrawAmount).toEqual(rewardWithdrawAmount);
+                    expect(res.body.state).toEqual(1);
+
                     done();
                 });
         });
@@ -381,9 +397,8 @@ describe('Happy Flow', () => {
                 })
                 .set({ AssetPool: poolAddress, Authorization: userAccessToken })
                 .end(async (err, res) => {
-                    redirectURL = res.headers.location;
-
                     expect(res.status).toBe(302);
+                    redirectURL = res.headers.location;
                     done();
                 });
         });
@@ -394,7 +409,7 @@ describe('Happy Flow', () => {
                 .end(async (err, res) => {
                     withdrawPollID = res.body.pollId;
                     expect(res.body.approved).toEqual(true); // polls are bypassed by defailt
-                    expect(Number(formatEther(res.body.amount))).toEqual(Number(formatEther(rewardWithdrawAmount)));
+                    expect(Number(formatEther(res.body.amount))).toEqual(rewardWithdrawAmount);
                     expect(res.status).toBe(200);
                     done();
                 });
@@ -420,7 +435,7 @@ describe('Happy Flow', () => {
             user.get(`/v1/withdrawals/${withdrawPollID}`)
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
                 .end(async (err, res) => {
-                    expect(Number(formatEther(res.body.amount))).toEqual(Number(formatEther(rewardWithdrawAmount)));
+                    expect(Number(formatEther(res.body.amount))).toEqual(rewardWithdrawAmount);
                     expect(res.body.beneficiary).toEqual(userWallet.address);
                     expect(res.body.approved).toEqual(true);
                     expect(res.status).toBe(200);
@@ -472,7 +487,7 @@ describe('Happy Flow', () => {
             user.get(redirectURL)
                 .set({ AssetPool: poolAddress, Authorization: adminAccessToken })
                 .end(async (err, res) => {
-                    expect(Number(formatEther(res.body.token.balance))).toBe(Number(formatEther(rewardWithdrawAmount)));
+                    expect(Number(formatEther(res.body.token.balance))).toBe(rewardWithdrawAmount);
                     expect(res.status).toBe(200);
                     done();
                 });

--- a/test/e2e/bypasspoll.ts
+++ b/test/e2e/bypasspoll.ts
@@ -39,10 +39,6 @@ describe('Bypass Polls', () => {
     });
 
     describe('POST /rewards 1 (bypass disabled)', () => {
-        beforeAll(async () => {
-            await downgradeFromBypassPolls(solutionContract(poolAddress));
-        });
-
         it('HTTP 302 redirect OK', (done) => {
             user.post('/v1/rewards')
                 .set({

--- a/test/e2e/lib/constants.ts
+++ b/test/e2e/lib/constants.ts
@@ -3,7 +3,7 @@ import { parseEther } from 'ethers/lib/utils';
 export const poolTitle = 'Volunteers United';
 export const rewardPollDuration = 10;
 export const proposeWithdrawPollDuration = 10;
-export const rewardWithdrawAmount = parseEther('1000');
+export const rewardWithdrawAmount = 1000;
 export const rewardWithdrawDuration = 12;
 export const VOTER_PK = '0x97093724e1748ebfa6aa2d2ec4ec68df8678423ab9a12eb2d27ddc74e35e5db9';
 export const mintAmount = parseEther('1000000');


### PR DESCRIPTION
@robertragas Some notable changes:
- `POST /asset_pools` timeouts should be resolved.
- `PATCH /asset_pools/:address` needs to be called with this payload `{"bypassPolls": true}` to enable bypassing polls.
- `POST /rewards` takes input in Ether instead of Wei (this means you can pass normal numbers as you tried earlier)
- `PATCH /rewards/:id` contained a tiny bug I noticed in the logs thats also fixed now. We did not implement this endpoint though since it requires the QR flow to authorise the transaction. 
