### PR TITLE
Logging improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:16-alpine as develop
 
-ENV NODE_ENV=develop
-
 WORKDIR /usr/src/app
 
 RUN apk add g++ make py3-pip
@@ -14,8 +12,6 @@ COPY . .
 CMD [ "ts-node", "src/server.ts" ]
 
 FROM node:16-alpine as build
-
-ENV NODE_ENV=develop
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:16-alpine as develop
 
+ENV NODE_ENV=develop
+
 WORKDIR /usr/src/app
 
 RUN apk add g++ make py3-pip
@@ -13,6 +15,8 @@ CMD [ "ts-node", "src/server.ts" ]
 
 FROM node:16-alpine as build
 
+ENV NODE_ENV=develop
+
 WORKDIR /usr/src/app
 
 COPY --from=develop ./usr/src/app/ ./
@@ -22,6 +26,8 @@ RUN npm run build
 CMD [ "node", "dist/src/server.js" ]
 
 FROM node:16-alpine as production
+
+ENV NODE_ENV=production
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install --ci
 
 COPY . .
 
-CMD [ "ts-node", "src/server.ts" ]
+CMD [ "npx", "ts-node", "src/server.ts" ]
 
 FROM node:16-alpine as build
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,8 +43,7 @@
                 "qrcode": "^1.5.0",
                 "swagger-ui-express": "^4.3.0",
                 "web3": "^1.3.6",
-                "winston": "^3.2.1",
-                "winston-daily-rotate-file": "^4.5.5"
+                "winston": "^3.2.1"
             },
             "devDependencies": {
                 "@types/async": "^3.0.2",
@@ -9937,7 +9936,7 @@
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
             "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "devOptional": true,
+            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -15606,14 +15605,6 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
-            }
-        },
-        "node_modules/file-stream-rotator": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.5.7.tgz",
-            "integrity": "sha512-VYb3HZ/GiAGUCrfeakO8Mp54YGswNUHvL7P09WQcXAJNSj3iQ5QraYSp3cIn1MUyw6uzfgN/EFOarCNa4JvUHQ==",
-            "dependencies": {
-                "moment": "^2.11.2"
             }
         },
         "node_modules/file-uri-to-path": {
@@ -24760,14 +24751,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/object-hash": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
-            "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==",
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/object-inspect": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
@@ -31286,23 +31269,6 @@
                 "node": ">= 6.4.0"
             }
         },
-        "node_modules/winston-daily-rotate-file": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-4.5.5.tgz",
-            "integrity": "sha512-ds0WahIjiDhKCiMXmY799pDBW+58ByqIBtUcsqr4oDoXrAI3Zn+hbgFdUxzMfqA93OG0mPLYVMiotqTgE/WeWQ==",
-            "dependencies": {
-                "file-stream-rotator": "^0.5.7",
-                "object-hash": "^2.0.1",
-                "triple-beam": "^1.3.0",
-                "winston-transport": "^4.4.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "peerDependencies": {
-                "winston": "^3"
-            }
-        },
         "node_modules/winston-transport": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
@@ -31501,6 +31467,7 @@
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
             "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
             "dependencies": {
                 "cliui": "^7.0.2",
                 "escalade": "^3.1.1",
@@ -31624,12 +31591,14 @@
         "node_modules/yargs/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true
         },
         "node_modules/yargs/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -31638,6 +31607,7 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
             "dependencies": {
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
@@ -31651,6 +31621,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
@@ -31679,6 +31650,7 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             }
@@ -31687,6 +31659,7 @@
             "version": "20.2.9",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
             "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
             "engines": {
                 "node": ">=10"
             }
@@ -39208,7 +39181,7 @@
             "version": "8.7.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
             "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "devOptional": true
+            "dev": true
         },
         "acorn-globals": {
             "version": "6.0.0",
@@ -43804,14 +43777,6 @@
             "dev": true,
             "requires": {
                 "flat-cache": "^3.0.4"
-            }
-        },
-        "file-stream-rotator": {
-            "version": "0.5.7",
-            "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.5.7.tgz",
-            "integrity": "sha512-VYb3HZ/GiAGUCrfeakO8Mp54YGswNUHvL7P09WQcXAJNSj3iQ5QraYSp3cIn1MUyw6uzfgN/EFOarCNa4JvUHQ==",
-            "requires": {
-                "moment": "^2.11.2"
             }
         },
         "file-uri-to-path": {
@@ -51111,11 +51076,6 @@
                 }
             }
         },
-        "object-hash": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
-            "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ=="
-        },
         "object-inspect": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
@@ -56428,17 +56388,6 @@
                 }
             }
         },
-        "winston-daily-rotate-file": {
-            "version": "4.5.5",
-            "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-4.5.5.tgz",
-            "integrity": "sha512-ds0WahIjiDhKCiMXmY799pDBW+58ByqIBtUcsqr4oDoXrAI3Zn+hbgFdUxzMfqA93OG0mPLYVMiotqTgE/WeWQ==",
-            "requires": {
-                "file-stream-rotator": "^0.5.7",
-                "object-hash": "^2.0.1",
-                "triple-beam": "^1.3.0",
-                "winston-transport": "^4.4.0"
-            }
-        },
         "winston-transport": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
@@ -56612,6 +56561,7 @@
             "version": "16.2.0",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
             "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
             "requires": {
                 "cliui": "^7.0.2",
                 "escalade": "^3.1.1",
@@ -56660,17 +56610,20 @@
                 "emoji-regex": {
                     "version": "8.0.0",
                     "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
                 },
                 "string-width": {
                     "version": "4.2.3",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
                     "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                    "dev": true,
                     "requires": {
                         "emoji-regex": "^8.0.0",
                         "is-fullwidth-code-point": "^3.0.0",
@@ -56681,6 +56634,7 @@
                     "version": "6.0.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
                     "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^5.0.1"
                     }
@@ -56699,12 +56653,14 @@
                 "y18n": {
                     "version": "5.0.8",
                     "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-                    "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+                    "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+                    "dev": true
                 },
                 "yargs-parser": {
                     "version": "20.2.9",
                     "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+                    "dev": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -62,8 +62,7 @@
         "qrcode": "^1.5.0",
         "swagger-ui-express": "^4.3.0",
         "web3": "^1.3.6",
-        "winston": "^3.2.1",
-        "winston-daily-rotate-file": "^4.5.5"
+        "winston": "^3.2.1"
     },
     "devDependencies": {
         "@types/async": "^3.0.2",

--- a/scripts/deployAssetPoolFactory.ts
+++ b/scripts/deployAssetPoolFactory.ts
@@ -1,8 +1,5 @@
-import dotenv from 'dotenv';
 import { NetworkProvider } from '../src/util/network';
 import { deployFactory } from './lib/factory';
-
-dotenv.config();
 
 async function main() {
     console.log('Asset Pool Factory [Test]: ', await deployFactory(NetworkProvider.Test));

--- a/scripts/deployAssetPoolRegistry.ts
+++ b/scripts/deployAssetPoolRegistry.ts
@@ -1,8 +1,5 @@
-import dotenv from 'dotenv';
 import { deployRegistry } from './lib/registry';
 import { NetworkProvider } from '../src/util/network';
-
-dotenv.config();
 
 async function main() {
     console.log('Asset Pool Registry [Test]:', await deployRegistry(NetworkProvider.Test));

--- a/scripts/deployFacets.ts
+++ b/scripts/deployFacets.ts
@@ -1,8 +1,5 @@
-import dotenv from 'dotenv';
 import { NetworkProvider } from '../src/util/network';
 import { deployFacets } from './lib/facets';
-
-dotenv.config();
 
 async function main() {
     console.log('Facets [Test]:', await deployFacets(NetworkProvider.Test));

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,7 +25,7 @@ const options = {
 
 createTerminus(server, options);
 
-logger.info(`server is starting on port ${app.get('port')}`);
+logger.info(`Server is starting on port ${app.get('port')}`);
 server.listen(app.get('port'));
 
 export default server;

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,7 @@ const options = {
         'verbatim': true,
     },
     onSignal: (): Promise<any> => {
-        logger.info('Server is starting cleanup');
+        logger.info('Server shutting down');
         return Promise.all([db.disconnect(), agenda.stop()]);
     },
     logger: logger.error,

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,6 @@ import { createTerminus } from '@godaddy/terminus';
 import { healthCheck } from './util/healthcheck';
 import { logger } from './util/logger';
 import { agenda } from './util/agenda';
-import { ENVIRONMENT } from './util/secrets';
 
 const server = http.createServer(app);
 
@@ -26,7 +25,7 @@ const options = {
 
 createTerminus(server, options);
 
-logger.info(`Server is starting on port: ${app.get('port')}, env: ${ENVIRONMENT}`);
+logger.info(`Server is starting on port: ${app.get('port')}, env: ${app.get('env')}`);
 server.listen(app.get('port'));
 
 export default server;

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { createTerminus } from '@godaddy/terminus';
 import { healthCheck } from './util/healthcheck';
 import { logger } from './util/logger';
 import { agenda } from './util/agenda';
+import { ENVIRONMENT } from './util/secrets';
 
 const server = http.createServer(app);
 
@@ -25,7 +26,7 @@ const options = {
 
 createTerminus(server, options);
 
-logger.info(`Server is starting on port ${app.get('port')}`);
+logger.info(`Server is starting on port: ${app.get('port')}, env: ${ENVIRONMENT}`);
 server.listen(app.get('port'));
 
 export default server;

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,7 @@ const options = {
 
 createTerminus(server, options);
 
+logger.info(`server is starting on port ${app.get('port')}`);
 server.listen(app.get('port'));
 
 export default server;

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,22 +8,31 @@ import { agenda } from './util/agenda';
 
 const server = http.createServer(app);
 
-// Called on server close
-function onSignal(): Promise<any> {
-    logger.info('Server is starting cleanup');
-    return Promise.all([db.disconnect(), agenda.stop()]);
-}
-
 const options = {
     healthChecks: {
         '/healthcheck': healthCheck,
         'verbatim': true,
     },
-    onSignal,
+    onSignal: (): Promise<any> => {
+        logger.info('Server is starting cleanup');
+        return Promise.all([db.disconnect(), agenda.stop()]);
+    },
     logger: logger.error,
 };
 
 createTerminus(server, options);
+
+process.on('uncaughtException', function (err: Error) {
+    if (err) {
+        logger.error({
+            message: 'Uncaught Exception was thrown, shutting down',
+            errorName: err.name,
+            errorMessage: err.message,
+            stack: err.stack,
+        });
+        process.exit(1);
+    }
+});
 
 logger.info(`Server is starting on port: ${app.get('port')}, env: ${app.get('env')}`);
 server.listen(app.get('port'));

--- a/src/util/database.ts
+++ b/src/util/database.ts
@@ -12,24 +12,22 @@ const connect = async (url: string) => {
         useUnifiedTopology: true,
     };
 
-    if (mongoose.connection.readyState === 0) {
-        await mongoose.connect(url, mongooseOpts);
-    }
-
     mongoose.connection.on('error', (err) => {
-        if (err) {
-            logger.error(`${url}: ${err}`);
-        }
-        if (err.message.code === 'ETIMEDOUT') {
-            mongoose.connect(url, mongooseOpts);
-        }
         logger.error(`MongoDB connection error. Please make sure MongoDB is running. ${err}`);
+    });
+
+    mongoose.connection.on('reconnectFailed', (err) => {
+        logger.error('Unable to recoonect to MongoDB');
         process.exit();
     });
 
-    mongoose.connection.once('open', () => {
-        logger.info(`MongoDB successfully connected to ${url}`);
+    mongoose.connection.on('open', () => {
+        logger.info(`MongoDB successfully connected to ${url.split('@')[1]}`);
     });
+
+    if (mongoose.connection.readyState === 0) {
+        await mongoose.connect(url, mongooseOpts);
+    }
 };
 
 const truncate = async () => {

--- a/src/util/healthcheck.ts
+++ b/src/util/healthcheck.ts
@@ -31,5 +31,5 @@ const migrationsApplied: HealthCheck = async () => {
 };
 
 export const healthCheck: HealthCheck = () => {
-    return Promise.all([dbConnected(), migrationsApplied()]);
+    return Promise.all([dbConnected, migrationsApplied]);
 };

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -12,8 +12,8 @@ const formatWinston = winston.format.combine(
     winston.format.json(),
 );
 
-const instance = winston.createLogger({
-    level: 'info',
+export const logger = winston.createLogger({
+    level: 'http',
     format: formatWinston,
     transports: [
         new winston.transports.DailyRotateFile({
@@ -34,14 +34,9 @@ const instance = winston.createLogger({
     ],
 });
 
-if (ENVIRONMENT !== 'production' && ENVIRONMENT !== 'development') {
-    instance.add(new winston.transports.Console());
-    instance.debug('Logging initialized at debug level');
+if (ENVIRONMENT !== 'production') {
+    logger.add(new winston.transports.Console());
 }
-
-// morgan.token('timestamp', function getTimestamp() {
-//     return new Date().toISOString().replace('T', ' ').substr(0, 19);
-// });
 
 const formatMorgan = json({
     'method': ':method',
@@ -54,8 +49,7 @@ const formatMorgan = json({
     'user-agent': ':user-agent',
 });
 
-export const logger = instance;
 export const requestLogger = morgan(formatMorgan, {
     skip: (req: Request) => req.baseUrl && req.baseUrl.startsWith(`/${VERSION}/ping`),
-    stream: { write: (message: string) => instance.info(JSON.parse(message)) },
+    stream: { write: (message: string) => logger.http(JSON.parse(message)) },
 });

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,9 +1,8 @@
 import morgan from 'morgan';
 import json from 'morgan-json';
 import winston from 'winston';
-import 'winston-daily-rotate-file';
 import { Request } from 'express';
-import { ENVIRONMENT, VERSION } from './secrets';
+import { VERSION } from './secrets';
 
 const formatWinston = winston.format.combine(
     winston.format.timestamp({
@@ -15,28 +14,8 @@ const formatWinston = winston.format.combine(
 export const logger = winston.createLogger({
     level: 'http',
     format: formatWinston,
-    transports: [
-        new winston.transports.DailyRotateFile({
-            filename: 'logs/error/%DATE%.log',
-            datePattern: 'YYYY-MM-DD-HH',
-            zippedArchive: true,
-            maxSize: '5m',
-            maxFiles: '30d',
-            level: 'error',
-        }),
-        new winston.transports.DailyRotateFile({
-            filename: 'logs/combined/%DATE%.log',
-            datePattern: 'YYYY-MM-DD-HH',
-            zippedArchive: true,
-            maxSize: '5m',
-            maxFiles: '30d',
-        }),
-    ],
+    transports: [new winston.transports.Console()],
 });
-
-if (ENVIRONMENT !== 'production') {
-    logger.add(new winston.transports.Console());
-}
 
 const formatMorgan = json({
     'method': ':method',

--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Response } from 'express';
 import {
-    ENVIRONMENT,
     PRIVATE_KEY,
     TESTNET_ASSET_POOL_FACTORY_ADDRESS,
     ASSET_POOL_FACTORY_ADDRESS,
@@ -20,6 +19,7 @@ import { Contract } from 'web3-eth-contract';
 import { Artifacts } from './artifacts';
 import { logger } from './logger';
 import { toWei } from 'web3-utils';
+import app from '../app';
 
 export enum NetworkProvider {
     Test = 0,
@@ -61,7 +61,10 @@ export async function getGasPriceFromOracle(type: string) {
 export async function getGasPrice(npid: NetworkProvider) {
     const web3 = getProvider(npid);
 
-    if (ENVIRONMENT === 'local' || (ENVIRONMENT !== 'test' && npid === NetworkProvider.Test)) {
+    if (
+        ['development', 'local'].includes(app.get('env')) ||
+        (app.get('env') !== 'test' && npid === NetworkProvider.Test)
+    ) {
         return await web3.eth.getGasPrice();
     }
 

--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -7,6 +7,7 @@ import {
     RPC,
     MINIMUM_GAS_LIMIT,
     MAXIMUM_GAS_PRICE,
+    NODE_ENV,
 } from './secrets';
 import Web3 from 'web3';
 import axios from 'axios';
@@ -19,7 +20,6 @@ import { Contract } from 'web3-eth-contract';
 import { Artifacts } from './artifacts';
 import { logger } from './logger';
 import { toWei } from 'web3-utils';
-import app from '../app';
 
 export enum NetworkProvider {
     Test = 0,
@@ -61,10 +61,7 @@ export async function getGasPriceFromOracle(type: string) {
 export async function getGasPrice(npid: NetworkProvider) {
     const web3 = getProvider(npid);
 
-    if (
-        ['development', 'local'].includes(app.get('env')) ||
-        (app.get('env') !== 'test' && npid === NetworkProvider.Test)
-    ) {
+    if (['development', 'local'].includes(NODE_ENV) || (NODE_ENV !== 'test' && npid === NetworkProvider.Test)) {
         return await web3.eth.getGasPrice();
     }
 

--- a/src/util/secrets.ts
+++ b/src/util/secrets.ts
@@ -45,6 +45,7 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 export const VERSION = 'v1';
+export const NODE_ENV = process.env.NODE_ENV || 'development';
 export const ISSUER = process.env.ISSUER;
 export const SECURE_KEY = process.env.SECURE_KEY;
 export const AUTH_URL = process.env.AUTH_URL;

--- a/src/util/secrets.ts
+++ b/src/util/secrets.ts
@@ -45,7 +45,6 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 export const VERSION = 'v1';
-export const ENVIRONMENT = process.env.NODE_ENV;
 export const ISSUER = process.env.ISSUER;
 export const SECURE_KEY = process.env.SECURE_KEY;
 export const AUTH_URL = process.env.AUTH_URL;


### PR DESCRIPTION
This adds a couple of improvements, not all logging (sorry)

- Add startup logging
- Move http logs to http level
- Remove logfiles setup, always output to console
- Improve mongoDB logging so it actually logs and hides credentials
- Improve mongoDB connection events
- Log Uncaught Exceptions neatly
- Set default NODE_ENV in Docker images
- Don't use NODE_ENV directly but use app.get('env');
- Remove dotenv from deploy scripts


The only thing I'm not completely sure about is https://github.com/thxprotocol/api/pull/175/files#diff-4056c2979f2757cb2935983e9797bf95f8f5fdc81a252a6f78119812e8eb073dR65 . 

Do you set NODE_ENV=local locally? I assumed so :) I believe it's common practice to have NODE_ENV=development on your local machine, `test` for testing and `production` during "production-like" runs. So this would mean the dev/staging server also runs in production mode. This is good practice since it's exposed to the public.