### PR TITLE
feat: Resolve CORS issue, add origin into client

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "1.20.8",
+    "version": "1.22.0",
     "title": "THX API Specification",
     "description": "User guides are available at https://docs.thx.network."
   },
@@ -960,6 +960,11 @@
           },
           {
             "name": "limit",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "q",
             "in": "query",
             "type": "string"
           }
@@ -2557,6 +2562,15 @@
           }
         },
         "registrationAccessToken": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "example": "string"
+            }
+          }
+        },
+        "origin": {
           "type": "object",
           "properties": {
             "type": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
                 "morgan-json": "^1.1.0",
                 "multer": "^1.4.5-lts.1",
                 "newrelic": "^8.14.1",
+                "node-cache": "^5.1.2",
                 "qrcode": "^1.5.0",
                 "semver": "^7.3.5",
                 "short-uuid": "^4.2.0",
@@ -6121,6 +6122,14 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^6.2.0"
+            }
+        },
+        "node_modules/clone": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+            "engines": {
+                "node": ">=0.8"
             }
         },
         "node_modules/clone-response": {
@@ -12965,6 +12974,17 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
             "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+        },
+        "node_modules/node-cache": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+            "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+            "dependencies": {
+                "clone": "2.x"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            }
         },
         "node_modules/node-fetch": {
             "version": "2.6.7",
@@ -21642,6 +21662,11 @@
                 "wrap-ansi": "^6.2.0"
             }
         },
+        "clone": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+        },
         "clone-response": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
@@ -26934,6 +26959,14 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
             "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+        },
+        "node-cache": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+            "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+            "requires": {
+                "clone": "2.x"
+            }
         },
         "node-fetch": {
             "version": "2.6.7",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "morgan-json": "^1.1.0",
         "multer": "^1.4.5-lts.1",
         "newrelic": "^8.14.1",
+        "node-cache": "^5.1.2",
         "qrcode": "^1.5.0",
         "semver": "^7.3.5",
         "short-uuid": "^4.2.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,7 +10,7 @@ import path from 'path';
 
 import { MONGODB_URI, PORT, VERSION } from '@/config/secrets';
 import router from '@/controllers';
-import { errorLogger, errorNormalizer, errorOutput, notFoundHandler } from '@/middlewares';
+import { corsHandler, errorLogger, errorNormalizer, errorOutput, notFoundHandler } from '@/middlewares';
 import db from '@/util/database';
 import { requestLogger } from '@/util/logger';
 
@@ -29,8 +29,7 @@ app.use(lusca.xssProtection(true));
 app.use(express.static(path.join(__dirname, 'public'), { maxAge: 31557600000 }));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-// app.use(corsHandler);
-// app.use(cors('*'));
+app.use(corsHandler);
 app.use(`/${VERSION}`, router);
 app.use(notFoundHandler);
 app.use(errorLogger);

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,16 +1,18 @@
 import 'express-async-errors';
 import '@/config/openapi';
-import express from 'express';
-import compression from 'compression';
-import lusca from 'lusca';
-import path from 'path';
+
 import axios from 'axios';
 import axiosBetterStacktrace from 'axios-better-stacktrace';
+import compression from 'compression';
+import express from 'express';
+import lusca from 'lusca';
+import path from 'path';
+
+import { MONGODB_URI, PORT, VERSION } from '@/config/secrets';
 import router from '@/controllers';
+import { errorLogger, errorNormalizer, errorOutput, notFoundHandler } from '@/middlewares';
 import db from '@/util/database';
 import { requestLogger } from '@/util/logger';
-import { errorOutput, notFoundHandler, errorLogger, errorNormalizer, corsHandler } from '@/middlewares';
-import { PORT, VERSION, MONGODB_URI } from '@/config/secrets';
 
 axiosBetterStacktrace(axios);
 
@@ -27,7 +29,8 @@ app.use(lusca.xssProtection(true));
 app.use(express.static(path.join(__dirname, 'public'), { maxAge: 31557600000 }));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
-app.use(corsHandler);
+// app.use(corsHandler);
+// app.use(cors('*'));
 app.use(`/${VERSION}`, router);
 app.use(notFoundHandler);
 app.use(errorLogger);

--- a/src/middlewares/corsHandler.ts
+++ b/src/middlewares/corsHandler.ts
@@ -5,12 +5,12 @@ import ClientProxy from '@/proxies/ClientProxy';
 export const corsHandler = cors(async (req: any, callback: any) => {
     const origin = req.header('Origin');
     const allowedOrigins = [AUTH_URL, API_URL, WALLET_URL, DASHBOARD_URL, WIDGETS_URL];
-    const isAllowedOrigin = req.auth?.client_id ? await ClientProxy.isAllowedOrigin(req.auth.client_id, origin) : false;
+    const isAllowedOrigin = await ClientProxy.isAllowedOrigin(origin);
 
     if (!origin || allowedOrigins.includes(origin) || isAllowedOrigin) {
         callback(null, {
             credentials: true,
-            origin: allowedOrigins,
+            origin: allowedOrigins.push(origin),
         });
     } else {
         callback(new Error('Not allowed by CORS'));

--- a/src/models/Client.ts
+++ b/src/models/Client.ts
@@ -9,6 +9,7 @@ export type TClient = {
     clientSecret: string;
     requestUris: string[];
     registrationAccessToken: string;
+    origin?: string;
 };
 export type TClientPayload = {
     application_type: string;
@@ -29,6 +30,7 @@ const clientSchema = new mongoose.Schema(
         clientId: String,
         grantType: String,
         registrationAccessToken: String,
+        origin: String,
     },
     { timestamps: true },
 );

--- a/src/models/Client.ts
+++ b/src/models/Client.ts
@@ -9,7 +9,7 @@ export type TClient = {
     clientSecret: string;
     requestUris: string[];
     registrationAccessToken: string;
-    origin?: string;
+    origins?: string[];
 };
 export type TClientPayload = {
     application_type: string;

--- a/src/services/ERC20Service.ts
+++ b/src/services/ERC20Service.ts
@@ -104,6 +104,7 @@ export const findOrImport = async (pool: AssetPoolDocument, address: string) => 
         chainId: pool.chainId,
         type: ERC20Type.Unknown,
         sub: pool.sub,
+        archived: false,
     });
 
     // Create an ERC20Token object for the sub if it does not exist


### PR DESCRIPTION
**What**
- Resolve the CORS issue with the following steps:
  1. Save `request_uri` in `origin` inside the Client model when creating a new Client
  2. Query all clients when the application starts and store them inside node-cache
  3. Check them on OPTION preflight requests
  
**Notes**
- Other considerations:
  1. Doesn't store anything and Query all `request_uri` from Auth App. [Performance issue]
  2. Auth app doesn't need to update cause it have direct access to `redirect_uri` (and using it for CORS)
  
- After successfully achieving 203 API calls, seeing a new problem is token expires and doesn't seem to be renewed (with silent new turned on, working to do that manually)
   