### PR TITLE
Hotfix/ci hotfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     buildAndPushImage:
         name: Build and Push docker image
         runs-on: ubuntu-latest
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref,'refs/heads/hotfix/')
+        if: github.ref == 'refs/heads/main'
         needs: bumpVersion
         steps:
             - name: Checkout
@@ -90,6 +90,50 @@ jobs:
 
             - name: Set correct version
               run: npm version ${{needs.bumpVersion.outputs.newTag}} --allow-same-version=true --git-tag-version=false
+
+            - name: Build
+              uses: docker/build-push-action@v2
+              with:
+                  context: .
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}
+
+    buildAndPushHotfixImage:
+        name: Build and Push hotfix docker image
+        runs-on: ubuntu-latest
+        if: startsWith(github.ref,'refs/heads/hotfix/')
+        needs: buildAndTest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Install Node.js 16.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 16.x
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v1
+              with:
+                  aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+                  aws-region: eu-west-3
+
+            - name: Login to ECR
+              uses: docker/login-action@v1
+              with:
+                  registry: 275440070213.dkr.ecr.eu-west-3.amazonaws.com
+
+            - name: Docker meta
+              id: meta
+              uses: docker/metadata-action@v3
+              with:
+                  images: |
+                      275440070213.dkr.ecr.eu-west-3.amazonaws.com/api
+                  tags: |
+                      type=ref,event=branch
+                      type=sha
 
             - name: Build
               uses: docker/build-push-action@v2


### PR DESCRIPTION
Initially created to test deployments using the commit hash this branch introduces builds for branches starting with `hotfix/`. This means you can deploy them directly without merging to main first. I am somewhat tempted to remove the dependency on the test step so the image gets built and pushed before the tests finish and you can push the button to deploy as soon as the tests pass (or even before)..

@peterpolman what do you think?

This branch also deletes the `src/scss` dir so git doesn't trip up on the submodule info missing.