### PR TITLE
Add test override for hardhat rpc

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ WALLET_URL=https://localhost:8083
 WIDGETS_URL=https://localhost:8085
 
 HARDHAT_RPC=https://localhost:8546
+HARDHAT_RPC_TEST_OVERRIDE=http://localhost:8547
 POLYGON_MUMBAI_RPC=https://polygon-mumbai.infura.io/v3/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 POLYGON_RPC=https://polygon-mainnet.infura.io/v3/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 


### PR DESCRIPTION
The tests require hardhat to be accessed over http. This var is required to run the tests locally.