### PR TITLE
add error info when calling logger.error(error)

### DIFF
--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -8,6 +8,7 @@ const formatWinston = winston.format.combine(
     winston.format.timestamp({
         format: 'YYYY-MM-DD HH:mm:ss',
     }),
+    winston.format.errors({ stack: true }),
     winston.format.json(),
 );
 


### PR DESCRIPTION
gets you 
` {"level":"error","message":"E-mail address for account not set","stack":"Error: E-mail address for account not set\n    at Object.generateRewardQRCodesJob [as fn] (/Users/bram/Projects/thx/api/src/jobs/rewardQRcodesJob.ts:34:35)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)","timestamp":"2022-10-02 14:20:59"}` 

instead of 
` {"level":"error", "timestamp":"2022-10-02 14:20:59"}`