### PR TITLE
Async deploys

### DIFF
--- a/src/controllers/erc20/get.controller.ts
+++ b/src/controllers/erc20/get.controller.ts
@@ -16,8 +16,13 @@ const controller = async (req: Request, res: Response) => {
             schema: { $ref: '#/definitions/ERC20' } 
     }
     */
-    const erc20 = await ERC20Service.getById(req.params.id);
+    let erc20 = await ERC20Service.queryDeployTransaction(await ERC20Service.getById(req.params.id));
     if (!erc20) new NotFoundError('ERC20 not found');
+
+    // Check if pending transaction is mined.
+    if (!erc20.address) erc20 = await ERC20Service.queryDeployTransaction(erc20);
+
+    // Still no address.
     if (!erc20.address) return res.send(erc20);
 
     const { defaultAccount } = getProvider(erc20.chainId);

--- a/src/controllers/erc20/post.controller.ts
+++ b/src/controllers/erc20/post.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { body, check } from 'express-validator';
+import { body, check, query } from 'express-validator';
 import ERC20Service from '@/services/ERC20Service';
 import AccountProxy from '@/proxies/AccountProxy';
 import { checkAndUpgradeToBasicPlan } from '@/util/plans';
@@ -17,6 +17,7 @@ export const validation = [
         .custom((value, { req }) => {
             return ['jpg', 'jpeg', 'gif', 'png'].includes(req.file.mimetype);
         }),
+    query('forceSync').optional().isBoolean(),
 ];
 
 export const controller = async (req: Request, res: Response) => {
@@ -37,15 +38,20 @@ export const controller = async (req: Request, res: Response) => {
         logoImgUrl = ImageService.getPublicUrl(response.key);
     }
 
-    const erc20 = await ERC20Service.deploy({
-        name: req.body.name,
-        symbol: req.body.symbol,
-        chainId: req.body.chainId,
-        totalSupply: req.body.totalSupply,
-        type: req.body.type,
-        sub: req.auth.sub,
-        logoImgUrl,
-    });
+    const forceSync = req.query.forceSync !== undefined ? Boolean(req.query.forceSync) : false;
+
+    const erc20 = await ERC20Service.deploy(
+        {
+            name: req.body.name,
+            symbol: req.body.symbol,
+            chainId: req.body.chainId,
+            totalSupply: req.body.totalSupply,
+            type: req.body.type,
+            sub: req.auth.sub,
+            logoImgUrl,
+        },
+        forceSync,
+    );
 
     res.status(201).json(erc20);
 };

--- a/src/controllers/erc721/get.controller.ts
+++ b/src/controllers/erc721/get.controller.ts
@@ -13,9 +13,14 @@ const controller = async (req: Request, res: Response) => {
         description: "Get information of the ERC721 contract.",
         schema: { $ref: '#/definitions/ERC721' } } 
     */
-    const erc721 = await ERC721Service.findById(req.params.id);
+    let erc721 = await ERC721Service.findById(req.params.id);
 
     if (!erc721) throw new NotFoundError();
+
+    // Check if pending transaction is mined.
+    if (!erc721.address) erc721 = await ERC721Service.queryDeployTransaction(erc721);
+
+    // Still no address.
     if (!erc721.address) return res.send(erc721);
 
     const totalSupply = await erc721.contract.methods.totalSupply().call();

--- a/src/controllers/erc721/post.controller.ts
+++ b/src/controllers/erc721/post.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { body, check } from 'express-validator';
+import { body, check, query } from 'express-validator';
 import ERC721Service from '@/services/ERC721Service';
 import ImageService from '@/services/ImageService';
 import { BadRequestError } from '@/util/errors';
@@ -15,6 +15,7 @@ const validation = [
         .custom((value, { req }) => {
             return ['jpg', 'jpeg', 'gif', 'png'].includes(req.file.mimetype);
         }),
+    query('forceSync').optional().isBoolean(),
 ];
 
 const controller = async (req: Request, res: Response) => {
@@ -36,16 +37,21 @@ const controller = async (req: Request, res: Response) => {
         throw new BadRequestError('schema must be an Array');
     }
 
-    const erc721 = await ERC721Service.deploy({
-        sub: req.auth.sub,
-        chainId: req.body.chainId,
-        name: req.body.name,
-        symbol: req.body.symbol,
-        description: req.body.description,
-        properties,
-        archived: false,
-        logoImgUrl,
-    });
+    const forceSync = req.query.forceSync !== undefined ? Boolean(req.query.forceSync) : false;
+
+    const erc721 = await ERC721Service.deploy(
+        {
+            sub: req.auth.sub,
+            chainId: req.body.chainId,
+            name: req.body.name,
+            symbol: req.body.symbol,
+            description: req.body.description,
+            properties,
+            archived: false,
+            logoImgUrl,
+        },
+        forceSync,
+    );
 
     res.status(201).json(erc721);
 };

--- a/src/services/ERC721Service.ts
+++ b/src/services/ERC721Service.ts
@@ -4,10 +4,10 @@ import { ERC721TokenState, TERC721, TERC721Metadata, TERC721Token } from '@/type
 import TransactionService from './TransactionService';
 import { getProvider } from '@/util/network';
 import { VERSION, API_URL } from '@/config/secrets';
-import { assertEvent, parseLogs } from '@/util/events';
+import { assertEvent, ExpectedEventNotFound, findEvent, parseLogs } from '@/util/events';
 import { AssetPoolDocument } from '@/models/AssetPool';
-import { ChainId } from '@/types/enums';
-import { getAbiForContractName, getByteCodeForContractName } from '@/config/contracts';
+import { ChainId, TransactionState } from '@/types/enums';
+import { getByteCodeForContractName, getContractFromName } from '@/config/contracts';
 import { ERC721Token, ERC721TokenDocument } from '@/models/ERC721Token';
 import { TAssetPool } from '@/types/TAssetPool';
 import { keccak256, toUtf8Bytes } from 'ethers/lib/utils';
@@ -16,26 +16,56 @@ import AccountProxy from '@/proxies/AccountProxy';
 import { paginatedResults } from '@/util/pagination';
 import MembershipService from './MembershipService';
 import AssetPoolService from './AssetPoolService';
-import { TERC721TokenMintCallbackArgs } from '@/types/TTransaction';
+import { TERC721DeployCallbackArgs, TERC721TokenMintCallbackArgs } from '@/types/TTransaction';
 import { TransactionReceipt } from 'web3-core';
+import { Transaction } from '@/models/Transaction';
 
-async function deploy(data: TERC721): Promise<ERC721Document> {
+const contractName = 'NonFungibleToken';
+
+async function deploy(data: TERC721, forceSync = true): Promise<ERC721Document> {
     const { defaultAccount } = getProvider(data.chainId);
-    const abi = getAbiForContractName('NonFungibleToken');
-    const bytecode = getByteCodeForContractName('NonFungibleToken');
+    // const abi = getAbiForContractName('NonFungibleToken');
+    const contract = getContractFromName(data.chainId, contractName);
+    const bytecode = getByteCodeForContractName(contractName);
     data.baseURL = `${API_URL}/${VERSION}/metadata/`;
 
-    const erc721 = new ERC721(data);
-    const contract = await TransactionService.deploy(
-        abi,
-        bytecode,
-        [erc721.name, erc721.symbol, erc721.baseURL, defaultAccount],
-        erc721.chainId,
-    );
+    const erc721 = await ERC721.create(data);
 
-    erc721.address = contract.options.address;
+    const fn = contract.deploy({
+        data: bytecode,
+        arguments: [erc721.name, erc721.symbol, erc721.baseURL, defaultAccount],
+    });
 
-    return await erc721.save();
+    const txId = await TransactionService.sendAsync(null, fn, erc721.chainId, forceSync, {
+        type: 'Erc721DeployCallback',
+        args: { erc721Id: String(erc721._id) },
+    });
+
+    return await ERC721.findByIdAndUpdate(erc721._id, { transactions: [txId] }, { new: true });
+}
+
+export async function deployCallback({ erc721Id }: TERC721DeployCallbackArgs, receipt: TransactionReceipt) {
+    const erc721 = await ERC721.findById(erc721Id);
+    const contract = getContractFromName(erc721.chainId, contractName);
+    const events = parseLogs(contract.options.jsonInterface, receipt.logs);
+
+    if (!findEvent('OwnershipTransferred', events) && !findEvent('Transfer', events)) {
+        throw new ExpectedEventNotFound('Transfer or OwnershipTransferred');
+    }
+
+    await ERC721.findByIdAndUpdate(erc721Id, { address: receipt.contractAddress });
+}
+
+export async function queryDeployTransaction(erc721: ERC721Document): Promise<ERC721Document> {
+    if (!erc721.address && erc721.transactions[0]) {
+        const tx = await Transaction.findById(erc721.transactions[0]);
+        const txResult = await TransactionService.queryTransactionStatusReceipt(tx);
+        if (txResult === TransactionState.Mined) {
+            erc721 = await findById(erc721._id);
+        }
+    }
+
+    return erc721;
 }
 
 const initialize = async (pool: AssetPoolDocument, address: string) => {
@@ -195,6 +225,7 @@ export const update = (erc721: ERC721Document, updates: IERC721Updates) => {
 
 export default {
     deploy,
+    deployCallback,
     findById,
     createMetadata,
     mint,
@@ -213,4 +244,5 @@ export default {
     parseAttributes,
     update,
     initialize,
+    queryDeployTransaction,
 };

--- a/src/services/TransactionService.ts
+++ b/src/services/TransactionService.ts
@@ -100,12 +100,15 @@ async function sendAsync(
     });
 
     if (relayer) {
-        const defenderTx = await relayer.sendTransaction({
-            to,
+        const args: any = {
             data,
             speed: RELAYER_SPEED,
             gasLimit: gas,
-        });
+        };
+        if (to) {
+            args.to = to;
+        }
+        const defenderTx = await relayer.sendTransaction(args);
 
         Object.assign(tx, {
             transactionId: defenderTx.transactionId,

--- a/src/services/TransactionService.ts
+++ b/src/services/TransactionService.ts
@@ -14,6 +14,7 @@ import ERC20SwapService from './ERC20SwapService';
 import ERC721Service from './ERC721Service';
 import PaymentService from './PaymentService';
 import WithdrawalService from './WithdrawalService';
+import { RelayerTransactionPayload } from 'defender-relay-client';
 
 function getById(id: string) {
     return Transaction.findById(id);
@@ -100,14 +101,13 @@ async function sendAsync(
     });
 
     if (relayer) {
-        const args: any = {
+        const args: RelayerTransactionPayload = {
             data,
             speed: RELAYER_SPEED,
             gasLimit: gas,
         };
-        if (to) {
-            args.to = to;
-        }
+        if (to) args.to = to;
+
         const defenderTx = await relayer.sendTransaction(args);
 
         Object.assign(tx, {

--- a/src/services/TransactionService.ts
+++ b/src/services/TransactionService.ts
@@ -210,6 +210,9 @@ async function executeCallback(tx: TransactionDocument, receipt: TransactionRece
         case 'Erc20DeployCallback':
             await erc20DeployCallback(tx.callback.args, receipt);
             break;
+        case 'Erc721DeployCallback':
+            await ERC721Service.deployCallback(tx.callback.args, receipt);
+            break;
         case 'assetPoolDeployCallback':
             await AssetPoolService.deployCallback(tx.callback.args, receipt);
             break;

--- a/src/services/TransactionService.ts
+++ b/src/services/TransactionService.ts
@@ -121,7 +121,7 @@ async function sendAsync(
                     const transaction = await getById(tx._id);
                     return queryTransactionStatusReceipt(transaction);
                 },
-                (trans: TTransaction) => trans.state === TransactionState.Sent,
+                (state: TransactionState) => state === TransactionState.Sent,
                 500,
             );
         }
@@ -256,7 +256,7 @@ async function queryTransactionStatusDefender(tx: TransactionDocument) {
         await tx.save();
     }
 
-    return tx;
+    return tx.state;
 }
 
 async function queryTransactionStatusReceipt(tx: TransactionDocument) {
@@ -276,7 +276,7 @@ async function queryTransactionStatusReceipt(tx: TransactionDocument) {
         await transactionMined(tx, receipt);
     }
 
-    return tx;
+    return tx.state;
 }
 
 async function findFailReason(transactions: string[]): Promise<string | undefined> {

--- a/src/types/TTransaction.ts
+++ b/src/types/TTransaction.ts
@@ -28,6 +28,15 @@ type ERC20DeployCallback = {
     args: TERC20DeployCallbackArgs;
 };
 
+export type TERC721DeployCallbackArgs = {
+    erc721Id: string;
+};
+
+type ERC721DeployCallback = {
+    type: 'Erc721DeployCallback';
+    args: TERC721DeployCallbackArgs;
+};
+
 export type TAssetPoolDeployCallbackArgs = {
     assetPoolId: string;
     chainId: number;
@@ -103,6 +112,7 @@ type WithdrawForCallback = {
 
 export type TTransactionCallback =
     | ERC20DeployCallback
+    | ERC721DeployCallback
     | AssetPoolDeployCallback
     | TopupCallback
     | DepositCallback


### PR DESCRIPTION
This actually runs the transactions for deploying tokens asynchronously. This means a POST on the token endpoints might return a document without an address.

By polling the GET endpoint of a token you can check if the transaction has been mined, if so, the token will now have an address.

The FE can already handle this behaviour, no changes required.

optionally, a caller of the POST endpoint can add a query parameter ?forceSync=true to force synchronous behaviour.